### PR TITLE
Floating table + caption + cross-reference + sidewaystable

### DIFF
--- a/R/dt_options.R
+++ b/R/dt_options.R
@@ -253,4 +253,5 @@ dt_options_tbl <-
     "quarto_use_bootstrap",              FALSE,  "quarto",           "logical", FALSE,
     "latex_use_longtable",               FALSE,  "latex",            "logical", FALSE,
     "latex_tbl_pos",                     FALSE,  "latex",            "value",   "!t",
+    "latex_use_sidewaystable",           FALSE,  "latex",            "logical", FALSE
   )[-1, ]

--- a/R/export.R
+++ b/R/export.R
@@ -639,7 +639,7 @@ as_raw_html <- function(
 #' The `gt_packages.sty` file would then contain the listed dependencies above:
 #'
 #' \preformatted{
-#'   \usepackage{booktabs, caption, longtable, colortbl, array}
+#'   \usepackage{booktabs, caption, longtable, rotating, colortbl, array}
 #' }
 #'
 #' @section Examples:
@@ -686,6 +686,9 @@ as_latex <- function(data) {
   # Create a LaTeX fragment for the start of the table
   table_start <- create_table_start_l(data = data)
 
+  # Create the caption component
+  caption_component <- create_caption_component_l(data = data)
+
   # Create the heading component
   heading_component <- create_heading_component_l(data = data)
 
@@ -721,23 +724,44 @@ as_latex <- function(data) {
 
 
   # Compose the LaTeX table
-  knitr::asis_output(
-    paste0(
-      wrap_start_statement,
-      table_width_statement,
-      fontsize_statement,
-      table_start,
-      heading_component,
-      columns_component,
-      body_component,
-      table_end,
-      footer_component,
-      wrap_end_statement,
-      collapse = ""
-    ),
-    meta = latex_packages
-  )
-}
+  if (dt_options_get_value(data = data, option = "latex_use_longtable")) {
+    knitr::asis_output(
+      paste0(
+        wrap_start_statement,
+        table_width_statement,
+        fontsize_statement,
+        table_start,
+        caption_component,
+        heading_component,
+        columns_component,
+        body_component,
+        table_end,
+        footer_component,
+        wrap_end_statement,
+        collapse = ""
+      ),
+      meta = latex_packages
+    )
+  } else {
+    knitr::asis_output(
+      paste0(
+        wrap_start_statement,
+        caption_component,
+        heading_component,
+        table_width_statement,
+        fontsize_statement,
+        table_start,
+        columns_component,
+        body_component,
+        table_end,
+        footer_component,
+        wrap_end_statement,
+        collapse = ""
+      ),
+      meta = latex_packages
+    )
+  }
+  }
 
 #' Output a **gt** object as RTF
 #'

--- a/R/knitr-utils.R
+++ b/R/knitr-utils.R
@@ -23,37 +23,30 @@
 
 
 kable_caption <- function(label, caption, format) {
-
-  if (is.null(label)) {
-    label <- knitr::opts_current$get("label")
+  # create a label for bookdown if applicable
+  if (is.null(label)) label <- knitr::opts_current$get("label")
+  if (is.null(label)) label <- NA
+  if (!is.null(caption) && !anyNA(caption) && !anyNA(label)) {
+    caption <- paste0(
+      create_label(
+        knitr::opts_knit$get("label.prefix")[["table"]],
+        label,
+        latex = (format == "latex")
+      ), caption
+    )
   }
-
-  if (!is.null(caption) && !is.na(caption)) {
-
-    caption <-
-      paste0(
-        create_label("tab:", label, latex = (format == "latex")), caption
-      )
-  }
-
   caption
 }
 
 create_label <- function(..., latex = FALSE) {
-
   if (isTRUE(knitr::opts_knit$get("bookdown.internal.label"))) {
-
-    lab1 <- "(#"
+    lab1 <- "(\\#"
     lab2 <- ")"
-
   } else if (latex) {
-
     lab1 <- "\\label{"
     lab2 <- "}"
-
   } else {
-    return("")
+    return("") # we don't want the label at all
   }
-
   paste(c(lab1, ..., lab2), collapse = "")
 }

--- a/R/tab_create_modify.R
+++ b/R/tab_create_modify.R
@@ -4450,6 +4450,13 @@ set_style.cells_source_notes <- function(loc, data, style) {
 #'   set the floating position within the code chunk argument `tbl-pos`. Table
 #'   will only float if longtable environment is set to `FALSE`.
 #'
+#' @param latex.use.sidewaystable
+#'
+#'   *Use sidewaystable latex environment*
+#'
+#'   Setting this parameter to `TRUE` will use the `sidewaystable` environment
+#'   which will rotate the table 90 degrees. This only works in a floating environment.
+#'
 #' @return An object of class `gt_tbl`.
 #'
 #' @section Examples:
@@ -4769,7 +4776,8 @@ tab_options <- function(
     quarto.use_bootstrap = NULL,
     quarto.disable_processing = NULL,
     latex.use.longtable = NULL,
-    latex.tbl.pos = NULL
+    latex.tbl.pos = NULL,
+    latex.use.sidewaystable = NULL
 ) {
 
   # Perform input object validation

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -176,7 +176,7 @@ utils::globalVariables(
 #' - `gt.latex_packages`: A vector of LaTeX package names to use when generating
 #' tables in the LaTeX output context. The set of packages loaded is controlled
 #' by this default vector:
-#' `c("booktabs", "caption", "longtable", "colortbl", "array")`.
+#' `c("booktabs", "caption", "longtable", "rotating", "colortbl", "array")`.
 #'
 #' @keywords internal
 #' @name gt-options
@@ -187,7 +187,7 @@ gt_default_options <-
     gt.row_group.sep = " - ",
     gt.html_tag_check = TRUE,
     gt.strict_column_fmt = FALSE,
-    gt.latex_packages = c("booktabs", "caption", "longtable", "colortbl", "array", "anyfontsize")
+    gt.latex_packages = c("booktabs", "caption", "longtable", "rotating", "colortbl", "array", "anyfontsize")
   )
 
 # R 3.5 and earlier have a bug on Windows where if x is latin1 or unknown and

--- a/man/as_latex.Rd
+++ b/man/as_latex.Rd
@@ -23,7 +23,7 @@ containing the LaTeX code.
 }
 \details{
 LaTeX packages required to generate tables are:
-booktabs, caption, longtable, colortbl, array, anyfontsize.
+booktabs, caption, longtable, rotating, colortbl, array, anyfontsize.
 
 In the event packages are not automatically added during the render phase
 of the document, please create and include a style file to load them.
@@ -40,7 +40,7 @@ output:
 The \code{gt_packages.sty} file would then contain the listed dependencies above:
 
 \preformatted{
-  \usepackage{booktabs, caption, longtable, colortbl, array}
+  \usepackage{booktabs, caption, longtable, rotating, colortbl, array}
 }
 }
 \section{Examples}{

--- a/man/gt-options.Rd
+++ b/man/gt-options.Rd
@@ -22,7 +22,7 @@ incompatible with the function. This is \code{FALSE} by default.
 \item \code{gt.latex_packages}: A vector of LaTeX package names to use when generating
 tables in the LaTeX output context. The set of packages loaded is controlled
 by this default vector:
-\code{c("booktabs", "caption", "longtable", "colortbl", "array")}.
+\code{c("booktabs", "caption", "longtable", "rotating", "colortbl", "array")}.
 }
 }
 

--- a/man/tab_options.Rd
+++ b/man/tab_options.Rd
@@ -192,7 +192,8 @@ tab_options(
   quarto.use_bootstrap = NULL,
   quarto.disable_processing = NULL,
   latex.use.longtable = NULL,
-  latex.tbl.pos = NULL
+  latex.tbl.pos = NULL,
+  latex.use.sidewaystable = NULL
 )
 }
 \arguments{
@@ -652,6 +653,11 @@ The latex position indicator for a floating environment (e.g. "!t", "H"). It
 should be specified without square brackets. Quarto users should instead
 set the floating position within the code chunk argument \code{tbl-pos}. Table
 will only float if longtable environment is set to \code{FALSE}.}
+
+\item{latex.use.sidewaystable}{\emph{Use sidewaystable latex environment}
+
+Setting this parameter to \code{TRUE} will use the \code{sidewaystable} environment
+which will rotate the table 90 degrees. This only works in a floating environment.}
 }
 \value{
 An object of class \code{gt_tbl}.
@@ -789,7 +795,7 @@ options. Here, we'll use the \code{"small"} keyword as a value for both options.
 }
 
 \seealso{
-Other part creation/modification functions: 
+Other part creation/modification functions:
 \code{\link{tab_caption}()},
 \code{\link{tab_footnote}()},
 \code{\link{tab_header}()},


### PR DESCRIPTION
- Added caption component to latex table (html caption component as template).
- Updated knitr helper functions. This makes it possible to cross-reference tables in bookdown.
- Heading component didn't work in floating table environment. This is now fixed.
- Added option to use sidewaystable environment + documentation.
- Added horizontal line over heading component to mimic html table output. This is not working for longtables.